### PR TITLE
feat: 회원 탈퇴, 비밀번호 변경 조건 추가

### DIFF
--- a/src/main/java/com/tbgram/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tbgram/domain/member/controller/MemberController.java
@@ -1,9 +1,10 @@
 package com.tbgram.domain.member.controller;
 
-import com.tbgram.domain.member.dto.MemberResponseDto;
-import com.tbgram.domain.member.dto.SignUpRequestDto;
-import com.tbgram.domain.member.dto.UpdateMemberRequestDto;
-import com.tbgram.domain.member.dto.UpdatePasswordRequestDto;
+import com.tbgram.domain.member.dto.request.DeleteMemberRequestDto;
+import com.tbgram.domain.member.dto.response.MemberResponseDto;
+import com.tbgram.domain.member.dto.request.SignUpRequestDto;
+import com.tbgram.domain.member.dto.request.UpdateMemberRequestDto;
+import com.tbgram.domain.member.dto.request.UpdatePasswordRequestDto;
 import com.tbgram.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ public class MemberController {
     }
 
     // 비밀번호수정
-    @PatchMapping("/{id}")
+    @PutMapping("/{id}/password")
     public ResponseEntity<MemberResponseDto> updatePassword(
             @PathVariable Long id,
             @RequestBody UpdatePasswordRequestDto requestDto){
@@ -58,8 +59,10 @@ public class MemberController {
 
     // 회원탈퇴
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        memberService.delete(id);
+    public ResponseEntity<Void> delete(
+            @PathVariable Long id,
+            @RequestBody DeleteMemberRequestDto requestDto) {
+        memberService.delete(id, requestDto.getPassword());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/tbgram/domain/member/dto/request/DeleteMemberRequestDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/request/DeleteMemberRequestDto.java
@@ -1,0 +1,12 @@
+package com.tbgram.domain.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeleteMemberRequestDto {
+
+    private String password;
+
+}

--- a/src/main/java/com/tbgram/domain/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/request/SignUpRequestDto.java
@@ -1,4 +1,4 @@
-package com.tbgram.domain.member.dto;
+package com.tbgram.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/tbgram/domain/member/dto/request/UpdateMemberRequestDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/request/UpdateMemberRequestDto.java
@@ -1,4 +1,4 @@
-package com.tbgram.domain.member.dto;
+package com.tbgram.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/com/tbgram/domain/member/dto/request/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/request/UpdatePasswordRequestDto.java
@@ -1,4 +1,4 @@
-package com.tbgram.domain.member.dto;
+package com.tbgram.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/com/tbgram/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/response/MemberResponseDto.java
@@ -1,4 +1,4 @@
-package com.tbgram.domain.member.dto;
+package com.tbgram.domain.member.dto.response;
 
 import com.tbgram.domain.member.entity.Member;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/tbgram/domain/member/service/MemberService.java
+++ b/src/main/java/com/tbgram/domain/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package com.tbgram.domain.member.service;
 
 import com.tbgram.config.PasswordEncoder;
-import com.tbgram.domain.member.dto.MemberResponseDto;
+import com.tbgram.domain.member.dto.response.MemberResponseDto;
 import com.tbgram.domain.member.entity.Member;
 import com.tbgram.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,10 @@ public class MemberService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
         if(!passwordEncoder.matches(oldPassword, member.getPassword())){
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호 불일치");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+        }
+        if(oldPassword.equals(newPassword)){
+            throw new IllegalArgumentException("동일한 비밀번호로 변경할 수 없습니다.");
         }
         String encodedNewPassword = passwordEncoder.encode(newPassword);
         member.updatePassword(encodedNewPassword);
@@ -50,11 +53,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, String password) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+        if(!passwordEncoder.matches(password, member.getPassword())){
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+        }
         member.delete();
-        memberRepository.save(member);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- 비밀번호 변경 시 동일한 비밀번호로는 변경 불가 
   -> equals()로 두 입력값 비교
- 회원 탈퇴시 비밀번호 검증 로직 추가 
   -> passwordEncoder의 matches() 사용 
   -> json 매핑을 위해 requestDto 생성

+ PatchMapping -> PutMapping으로 수정했습니다.
 전체적인 수정에 대한 부분은 PUT 요청으로 통일하는 것이 좋을 것 같은데, 의견 부탁드립니당 ~!😉