### PR TITLE
feat: email찾기 기능 구현

### DIFF
--- a/src/main/java/com/tbgram/domain/auth/dto/request/SigninRequestDto.java
+++ b/src/main/java/com/tbgram/domain/auth/dto/request/SigninRequestDto.java
@@ -1,8 +1,6 @@
 package com.tbgram.domain.auth.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/tbgram/domain/friends/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/tbgram/domain/friends/dto/response/FriendsResponseDto.java
@@ -1,10 +1,7 @@
 package com.tbgram.domain.friends.dto.response;
 
-import com.tbgram.domain.friends.dto.request.FriendsRequestDto;
 import com.tbgram.domain.friends.entity.Friends;
 import com.tbgram.domain.friends.enums.RequestStatus;
-import com.tbgram.domain.member.dto.MemberResponseDto;
-import com.tbgram.domain.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/tbgram/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tbgram/domain/member/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.tbgram.domain.member.controller;
 
-import com.tbgram.domain.member.dto.request.DeleteMemberRequestDto;
+import com.tbgram.domain.member.dto.request.*;
+import com.tbgram.domain.member.dto.response.FindEmailResponseDto;
 import com.tbgram.domain.member.dto.response.MemberResponseDto;
-import com.tbgram.domain.member.dto.request.SignUpRequestDto;
-import com.tbgram.domain.member.dto.request.UpdateMemberRequestDto;
-import com.tbgram.domain.member.dto.request.UpdatePasswordRequestDto;
 import com.tbgram.domain.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -71,6 +69,13 @@ public class MemberController {
     public ResponseEntity<MemberResponseDto> findById(@PathVariable Long id){
         MemberResponseDto memberResponseDto = memberService.findById(id);
         return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
+    }
+
+    // 이메일 찾기
+    @GetMapping("/email")
+    public ResponseEntity<FindEmailResponseDto> findEmailByNickName(@RequestBody FindEmailRequestDto requestDto){
+        FindEmailResponseDto findEmailResponseDto = memberService.findByEmailByNickName(requestDto.getNickName());
+        return new ResponseEntity<>(findEmailResponseDto, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/tbgram/domain/member/dto/request/FindEmailRequestDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/request/FindEmailRequestDto.java
@@ -1,0 +1,12 @@
+package com.tbgram.domain.member.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FindEmailRequestDto {
+
+    private String nickName;
+
+}

--- a/src/main/java/com/tbgram/domain/member/dto/response/FindEmailResponseDto.java
+++ b/src/main/java/com/tbgram/domain/member/dto/response/FindEmailResponseDto.java
@@ -1,0 +1,12 @@
+package com.tbgram.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindEmailResponseDto {
+
+    private final String email;
+
+}

--- a/src/main/java/com/tbgram/domain/member/entity/Member.java
+++ b/src/main/java/com/tbgram/domain/member/entity/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickName;
 
     @Column

--- a/src/main/java/com/tbgram/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/tbgram/domain/member/repository/MemberRepository.java
@@ -2,9 +2,22 @@ package com.tbgram.domain.member.repository;
 
 import com.tbgram.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Object> findByEmail(String email);
+
+    default Member findMemberByIdOrElseThrow(Long id){
+        return findById(id).orElseThrow(()
+                -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.")
+        );
+    }
+
+    Member findEmailByNickName(String nickName);
+
+    Optional<Object> findByNickName(String nickName);
 }

--- a/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
+++ b/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
@@ -50,7 +50,7 @@ public class NewsFeedService {
                 .map(NewsFeedResponseDto::new)
                 .toList();
 
-        return new NewsPageResponseDto<>(content, page.getNumber(), page.getTotalPages(), page.getTotalElements(), page.isFirst(), page.isLast());
+        return new NewsPageResponseDto<>(content, page.getNumber(), page.getTotalPages(), page.getTotalElements());
     }
 
     //뉴스피드 상세 조회


### PR DESCRIPTION
-> Member 필드중 email을 찾기위한 고유값이 없었기 때문에
	nickName 필드의 unique 속성을 true로 변경

-> signUp, updateMember에 nickName 변경시
	이미 존재하는 닉네임은 사용할수 없도록 변경

-> repository : findEmailByNickName(email 찾기에 사용),
	findByNickName(닉네임 중복 검증에 사용)

-> nickName을 전달해 email을 반환받는 각각의
	requestDto, responseDto 생성

+ 추가적으로 다른 도메인에 비활성화되어있는 import 메소드 제거했습니다. 작업하시다가 다시 추가되었다면, 순차적으로 merge할때 + - 사항으로 들어갈거라 문제 없을것이라 생각합니다.! 혹시 몰라 명시해두겠습니당 🌸