### PR TITLE
feat: LoginUser 어노테이션을 사용해 세션에서 로그인된 사용자 ID를 반환받도록 수정

### DIFF
--- a/src/main/java/com/tbgram/config/WebConfig.java
+++ b/src/main/java/com/tbgram/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.tbgram.config;
+
+import com.tbgram.domain.common.resolver.LoginUserHandlerMethodArgumentResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    private LoginUserHandlerMethodArgumentResolver loginUserHandlerMethodArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers){
+        argumentResolvers.add(loginUserHandlerMethodArgumentResolver);
+    }
+}

--- a/src/main/java/com/tbgram/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/tbgram/domain/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.tbgram.domain.auth.controller;
 import com.tbgram.domain.auth.consts.Consts;
 import com.tbgram.domain.auth.dto.request.SigninRequestDto;
 import com.tbgram.domain.auth.dto.session.SessionUser;
-import com.tbgram.domain.auth.dto.response.SigininResponseDto;
+import com.tbgram.domain.auth.dto.response.SigninResponseDto;
 import com.tbgram.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -24,10 +24,10 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signin")
-    private ResponseEntity<SigininResponseDto> signin (@RequestBody @Valid SigninRequestDto requestDto,
-                                                       HttpServletRequest request){
+    private ResponseEntity<SigninResponseDto> signin (@RequestBody @Valid SigninRequestDto requestDto,
+                                                      HttpServletRequest request){
 
-        SigininResponseDto responseDto = authService.signin(requestDto);
+        SigninResponseDto responseDto = authService.signin(requestDto);
         HttpSession session = request.getSession(false);
         if(session != null){
             throw new ResponseStatusException(HttpStatus.FORBIDDEN,"이미 로그인된 상태입니다.");

--- a/src/main/java/com/tbgram/domain/auth/dto/request/SigninRequestDto.java
+++ b/src/main/java/com/tbgram/domain/auth/dto/request/SigninRequestDto.java
@@ -1,8 +1,6 @@
 package com.tbgram.domain.auth.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/tbgram/domain/auth/dto/response/SigninResponseDto.java
+++ b/src/main/java/com/tbgram/domain/auth/dto/response/SigninResponseDto.java
@@ -3,13 +3,13 @@ package com.tbgram.domain.auth.dto.response;
 import lombok.Getter;
 
 @Getter
-public class SigininResponseDto {
+public class SigninResponseDto {
 
     private Long id;
     private String email;
     private String nickName;
 
-    public SigininResponseDto(Long id, String email, String nickName) {
+    public SigninResponseDto(Long id, String email, String nickName) {
         this.id = id;
         this.email = email;
         this.nickName = nickName;

--- a/src/main/java/com/tbgram/domain/auth/service/AuthService.java
+++ b/src/main/java/com/tbgram/domain/auth/service/AuthService.java
@@ -2,7 +2,7 @@ package com.tbgram.domain.auth.service;
 
 import com.tbgram.config.PasswordEncoder;
 import com.tbgram.domain.auth.dto.request.SigninRequestDto;
-import com.tbgram.domain.auth.dto.response.SigininResponseDto;
+import com.tbgram.domain.auth.dto.response.SigninResponseDto;
 import com.tbgram.domain.auth.repository.AuthRepository;
 import com.tbgram.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +16,14 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthRepository authRepository;
 
-    public SigininResponseDto signin(SigninRequestDto requestDto){
+    public SigninResponseDto signin(SigninRequestDto requestDto){
         Member member = authRepository.findByEmailOrElseThrow(requestDto.getEmail());
 
         if(!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())){
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 비밀번호입니다.");
         }
 
-        SigininResponseDto signinResponseDto = new SigininResponseDto(member.getId(), member.getEmail(), member.getNickName());
+        SigninResponseDto signinResponseDto = new SigninResponseDto(member.getId(), member.getEmail(), member.getNickName());
 
         return signinResponseDto;
     }

--- a/src/main/java/com/tbgram/domain/common/annotation/LoginUser.java
+++ b/src/main/java/com/tbgram/domain/common/annotation/LoginUser.java
@@ -1,0 +1,12 @@
+package com.tbgram.domain.common.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {
+}

--- a/src/main/java/com/tbgram/domain/common/resolver/LoginUserHandlerMethodArgumentResolver.java
+++ b/src/main/java/com/tbgram/domain/common/resolver/LoginUserHandlerMethodArgumentResolver.java
@@ -1,0 +1,33 @@
+package com.tbgram.domain.common.resolver;
+
+import com.tbgram.domain.auth.dto.session.SessionUser;
+import com.tbgram.domain.common.annotation.LoginUser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isLoginUserAnnotation = parameter.getParameterAnnotation(LoginUser.class) != null;
+        boolean isLong = Long.class.equals(parameter.getParameterType());
+        return isLoginUserAnnotation && isLong;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+        Long userId = ((SessionUser) session.getAttribute("loginUser")).getId();
+        return userId;
+    }
+}

--- a/src/main/java/com/tbgram/domain/friends/controller/FriendsController.java
+++ b/src/main/java/com/tbgram/domain/friends/controller/FriendsController.java
@@ -4,11 +4,18 @@ import com.tbgram.domain.auth.dto.session.SessionUser;
 import com.tbgram.domain.friends.dto.request.FriendsRequestDto;
 import com.tbgram.domain.friends.dto.request.FriendsRequestStatusDto;
 import com.tbgram.domain.friends.dto.response.FriendsResponseDto;
+import com.tbgram.domain.friends.dto.response.PageModelDto;
+import com.tbgram.domain.friends.entity.Friends;
+import com.tbgram.domain.friends.respository.FriendsRepository;
 import com.tbgram.domain.friends.service.FriendsService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/friends")
 public class FriendsController {
     private final FriendsService friendsService;
-
+    private final FriendsRepository friendsRepository;
     /**
      * 친구 요청
      *
@@ -71,4 +78,11 @@ public class FriendsController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping
+    public ResponseEntity<PageModelDto<FriendsResponseDto>> friendsList(Pageable pageable,
+                                                                        HttpServletRequest request){
+        HttpSession session = request.getSession(false);
+        Long userId = ((SessionUser) session.getAttribute("loginUser")).getId();
+        return ResponseEntity.ok(friendsService.getFriendsList(userId,pageable));
+    }
 }

--- a/src/main/java/com/tbgram/domain/friends/dto/response/FriendsResponseDto.java
+++ b/src/main/java/com/tbgram/domain/friends/dto/response/FriendsResponseDto.java
@@ -1,13 +1,9 @@
 package com.tbgram.domain.friends.dto.response;
 
-import com.tbgram.domain.friends.dto.request.FriendsRequestDto;
 import com.tbgram.domain.friends.entity.Friends;
 import com.tbgram.domain.friends.enums.RequestStatus;
-import com.tbgram.domain.member.dto.MemberResponseDto;
-import com.tbgram.domain.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/tbgram/domain/friends/dto/response/PageModelDto.java
+++ b/src/main/java/com/tbgram/domain/friends/dto/response/PageModelDto.java
@@ -1,0 +1,16 @@
+package com.tbgram.domain.friends.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PageModelDto<T> {
+    // 임시로 사용되는 Dto입니다.
+    private List<T> results;
+    private int page;
+    private int pageSize;
+    private Long totalElements;
+}

--- a/src/main/java/com/tbgram/domain/friends/respository/FriendsRepository.java
+++ b/src/main/java/com/tbgram/domain/friends/respository/FriendsRepository.java
@@ -1,6 +1,9 @@
 package com.tbgram.domain.friends.respository;
 
 import com.tbgram.domain.friends.entity.Friends;
+import com.tbgram.domain.friends.enums.RequestStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -13,4 +16,6 @@ public interface FriendsRepository extends JpaRepository<Friends,Long> {
     default Friends findByIdOrElseThrow(Long friendsId){
         return findById(friendsId).orElseThrow(()-> new ResponseStatusException(HttpStatus.NOT_FOUND,"존재하지 않는 요청입니다."));
     }
+
+    Page<Friends> findBySenderIdOrReceiverIdAndStatus(Long senderId, Long ReceiverId, RequestStatus status,Pageable pageable);
 }

--- a/src/main/java/com/tbgram/domain/friends/service/FriendsService.java
+++ b/src/main/java/com/tbgram/domain/friends/service/FriendsService.java
@@ -1,6 +1,7 @@
 package com.tbgram.domain.friends.service;
 
 import com.tbgram.domain.friends.dto.response.FriendsResponseDto;
+import com.tbgram.domain.friends.dto.response.PageModelDto;
 import com.tbgram.domain.friends.entity.Friends;
 import com.tbgram.domain.friends.enums.RequestStatus;
 import com.tbgram.domain.friends.respository.FriendsRepository;
@@ -8,12 +9,16 @@ import com.tbgram.domain.member.entity.Member;
 import com.tbgram.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -83,5 +88,20 @@ public class FriendsService {
         }
 
         friendRepository.delete(friends);
+    }
+
+    @Transactional(readOnly = true)
+    public PageModelDto<FriendsResponseDto> getFriendsList(Long userId,Pageable pageable) {
+        Page<Friends> friendsPage = friendRepository.findBySenderIdOrReceiverIdAndStatus(userId,userId,RequestStatus.ACCEPTED,pageable);
+
+        List<FriendsResponseDto> friendsResponseDtoList = friendsPage.getContent().stream()
+                .map(FriendsResponseDto::fromEntity)
+                .collect(Collectors.toList());
+        return new PageModelDto<>(
+                friendsResponseDtoList,
+                friendsPage.getNumber(),
+                friendsPage.getSize(),
+                friendsPage.getTotalElements()
+        );
     }
 }

--- a/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
+++ b/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
@@ -50,7 +50,7 @@ public class NewsFeedService {
                 .map(NewsFeedResponseDto::new)
                 .toList();
 
-        return new NewsPageResponseDto<>(content, page.getNumber(), page.getTotalPages(), page.getTotalElements(), page.isFirst(), page.isLast());
+        return new NewsPageResponseDto<>(content, page.getNumber(), page.getTotalPages(), page.getTotalElements());
     }
 
     //뉴스피드 상세 조회


### PR DESCRIPTION
- Session에서 userId를 Long타입으로 반환해주는 `@LoginUser` annotation 추가 
ex) 

- 수정 전
```
    @PostMapping
    private ResponseEntity<FriendsResponseDto> friendsRequest(@RequestBody FriendsRequestDto requestDto,
                                                              HttpServletRequest request) {
        HttpSession session = request.getSession(false);
        Long senderId = ((SessionUser) session.getAttribute("loginUser")).getId();
        return ResponseEntity.ok(friendsService.friendsRequest(senderId, requestDto.getReceiverId()));
    }
```
- 수정 후
```
    @PostMapping
    private ResponseEntity<FriendsResponseDto> friendsRequest(@RequestBody FriendsRequestDto requestDto,
                                                              @LoginUser Long senderId) {
        return ResponseEntity.ok(friendsService.friendsRequest(senderId, requestDto.getReceiverId()));
    }
```