### PR TITLE
Chore/member : 회원 수정/삭제시 로그인된 유저 id 사용

### DIFF
--- a/src/main/java/com/tbgram/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tbgram/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.tbgram.domain.member.controller;
 
+import com.tbgram.domain.common.annotation.LoginUser;
 import com.tbgram.domain.member.dto.request.DeleteMemberRequestDto;
 import com.tbgram.domain.member.dto.response.MemberResponseDto;
 import com.tbgram.domain.member.dto.request.SignUpRequestDto;
@@ -23,7 +24,12 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    // 회원가입
+    /**
+     * 회원가입
+     *
+     * @param requestDto 회원가입 요청
+     * @return 가입된 회원의 정보, 상태코드 201
+     */
     @PostMapping
     public ResponseEntity<MemberResponseDto> signUp(@RequestBody @Valid SignUpRequestDto requestDto) {
         MemberResponseDto memberResponseDto = memberService.signUp(
@@ -35,10 +41,16 @@ public class MemberController {
         return new ResponseEntity<>(memberResponseDto, HttpStatus.CREATED);
     }
 
-    // 회원정보수정
-    @PutMapping("/{id}")
+    /**
+     * 회원 정보 수정
+     *
+     * @param requestDto 회원정보 수정(닉네임, 한줄소개) 요청
+     * @param id 로그인된 사용자의 id값
+     * @return 수정된 회원의 정보, 상태코드 200
+     */
+    @PutMapping
     public ResponseEntity<MemberResponseDto> updateMember(
-            @PathVariable Long id,
+            @LoginUser Long id,
             @RequestBody @Valid UpdateMemberRequestDto requestDto) {
         MemberResponseDto memberResponseDto = memberService.updateMember(
                 id,
@@ -48,10 +60,16 @@ public class MemberController {
         return ResponseEntity.ok(memberResponseDto);
     }
 
-    // 비밀번호수정
-    @PutMapping("/{id}/password")
+    /**
+     * 비밀번호 수정
+     *
+     * @param requestDto 현재 비밀번호, 변경할 비밀번호 요청
+     * @param id 로그인된 사용자의 id값
+     * @return 비밀번호가 수정된 회원의 정보, 상태코드 200
+     */
+    @PutMapping("/password")
     public ResponseEntity<MemberResponseDto> updatePassword(
-            @PathVariable Long id,
+            @LoginUser Long id,
             @RequestBody UpdatePasswordRequestDto requestDto){
         MemberResponseDto memberResponseDto = memberService.updatePassword(
                 id,
@@ -61,10 +79,16 @@ public class MemberController {
         return ResponseEntity.ok(memberResponseDto);
     }
 
-    // 회원탈퇴
-    @DeleteMapping("/{id}")
+    /**
+     * 회원 탈퇴
+     *
+     * @param id 로그인된 사용자의 id값
+     * @param requestDto 현재 비밀번호(검증)
+     * @return -
+     */
+    @DeleteMapping("/delete")
     public ResponseEntity<Void> delete(
-            @PathVariable Long id,
+            @LoginUser Long id,
             @RequestBody DeleteMemberRequestDto requestDto) {
         memberService.delete(id, requestDto.getPassword());
         return ResponseEntity.noContent().build();
@@ -81,14 +105,24 @@ public class MemberController {
         return ResponseEntity.ok(MemberResponseDto.fromEntity(updatedMember));
     }
 
-    // 단건조회
+    /**
+     * 회원 단건 조회
+     *
+     * @param id 조회할 회원의 id값
+     * @return id값으로 조회된 회원 정보, 상태코드 200
+     */
     @GetMapping("/{id}")
     public ResponseEntity<MemberResponseDto> findById(@PathVariable Long id){
         MemberResponseDto memberResponseDto = memberService.findById(id);
         return new ResponseEntity<>(memberResponseDto, HttpStatus.OK);
     }
 
-    // 이메일 찾기
+    /**
+     * 회원 단건 조회
+     *
+     * @param requestDto email조회를 위한 nickName 요청
+     * @return nickName으로 조회된 회원의 email 반환, 상태코드 200
+     */
     @GetMapping("/email")
     public ResponseEntity<FindEmailResponseDto> findEmailByNickName(@RequestBody FindEmailRequestDto requestDto){
         FindEmailResponseDto findEmailResponseDto = memberService.findByEmailByNickName(requestDto.getNickName());

--- a/src/main/java/com/tbgram/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tbgram/domain/member/controller/MemberController.java
@@ -84,9 +84,9 @@ public class MemberController {
      *
      * @param id 로그인된 사용자의 id값
      * @param requestDto 현재 비밀번호(검증)
-     * @return -
+     * @return 상태코드 204 No Content 나오는거 같네용.
      */
-    @DeleteMapping("/delete")
+    @DeleteMapping
     public ResponseEntity<Void> delete(
             @LoginUser Long id,
             @RequestBody DeleteMemberRequestDto requestDto) {

--- a/src/main/java/com/tbgram/domain/member/service/MemberService.java
+++ b/src/main/java/com/tbgram/domain/member/service/MemberService.java
@@ -83,6 +83,7 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).get();
         member.updateProfile(nickName, introduction);
         return memberRepository.save(member);
+    }
 
     @Transactional(readOnly = true)
     public FindEmailResponseDto findByEmailByNickName(String nickName) {


### PR DESCRIPTION
- URL에 id값을 직접 넣으면 타인이 임의로 수정/삭제가 가능한 문제

-> @loginuser 사용으로 로그인 검증
-> updateMember(), updatePassword, delete()에 적용
-> 입력 parameter로 받던 id값 제거 후 각 요청 URL 수정
-> controller 단에 통일된 주석 추가