### PR TITLE
feat: 뉴스피드 검색기능 구현

### DIFF
--- a/src/main/java/com/tbgram/domain/member/controller/MemberController.java
+++ b/src/main/java/com/tbgram/domain/member/controller/MemberController.java
@@ -15,6 +15,8 @@ import com.tbgram.domain.member.service.MemberService;
 import com.tbgram.domain.newsfeed.dto.response.NewsFeedResponseDto;
 
 import com.tbgram.domain.newsfeed.service.NewsFeedService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,7 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping
+@RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
 
@@ -99,12 +101,17 @@ public class MemberController {
     @DeleteMapping
     public ResponseEntity<Void> delete(
             @LoginUser Long id,
-            @RequestBody DeleteMemberRequestDto requestDto) {
+            @RequestBody DeleteMemberRequestDto requestDto,
+            HttpServletRequest request) {
 
         // 뉴스피드 deletedAt 처리
         newsFeedService.softDeleteByMemberId(id);
-
         memberService.delete(id, requestDto.getPassword());
+
+        // 세션 제거
+        HttpSession session = request.getSession();
+        session.invalidate();
+
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/tbgram/domain/newsfeed/controller/NewsFeedController.java
+++ b/src/main/java/com/tbgram/domain/newsfeed/controller/NewsFeedController.java
@@ -129,5 +129,32 @@ public class NewsFeedController {
         return ResponseEntity.ok(responseDto);
     }
 
+    /**
+     *
+     * @param keyword 검색 내용
+     * @param type 검색 타임
+     * @param page
+     * @param size
+     * @return 검색된 뉴스피드 dto를 페이징한 정보로 반환
+     */
+    @GetMapping("/search")
+    public ResponseEntity<PageModelDto<NewsFeedResponseDto>> searchNewsFeeds(
+            @RequestParam String keyword,
+            @RequestParam(required = false) String type,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        PageModelDto<NewsFeedResponseDto> result;
+        if ("title".equalsIgnoreCase(type)) {
+            result = newsFeedService.searchByTitle(keyword, page, size);
+        } else if ("content".equalsIgnoreCase(type)){
+            result = newsFeedService.searchByContent(keyword, page, size);
+        }else {
+            result = newsFeedService.searchByTitleOrContent(keyword, page, size);
+        }
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+
 }
 

--- a/src/main/java/com/tbgram/domain/newsfeed/repository/NewsFeedRepository.java
+++ b/src/main/java/com/tbgram/domain/newsfeed/repository/NewsFeedRepository.java
@@ -1,5 +1,7 @@
 package com.tbgram.domain.newsfeed.repository;
 
+import com.tbgram.domain.common.dto.response.PageModelDto;
+import com.tbgram.domain.newsfeed.dto.response.NewsFeedResponseDto;
 import com.tbgram.domain.newsfeed.entity.NewsFeed;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,5 +26,14 @@ public interface NewsFeedRepository extends JpaRepository<NewsFeed, Long> {
 
     //특정 회원이 작성한 뉴스피드 전체 조회 (삭제되지 않은 데이터만)
     List<NewsFeed> findByMemberIdAndDeletedAtIsNull(Long memberId);
+
+    // 제목으로 뉴스피드 검색
+    Page<NewsFeed> findByTitleContaining(String keyword, Pageable pageable);
+
+    // 내용으로 뉴스피드 검색
+    Page<NewsFeed> findByContentsContaining(String keyword, Pageable pageable);
+
+    // 제목+내용으로 뉴스피드 검색 (제목, 내용중 키워드가 포함된 글 모두 검색)
+    Page<NewsFeed> findByTitleContainingOrContentsContaining(String titleKeyword, String contentsKeyword, Pageable pageable);
 }
 

--- a/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
+++ b/src/main/java/com/tbgram/domain/newsfeed/service/NewsFeedService.java
@@ -143,4 +143,36 @@ public class NewsFeedService {
 
         return new PageModelDto<>(newsFeedResponseDtos, page.getNumber() + 1, page.getSize(), page.getTotalElements());
     }
+
+    // 제목으로 검색
+    public PageModelDto<NewsFeedResponseDto> searchByTitle(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<NewsFeed> result = newsFeedRepository.findByTitleContaining(keyword, pageable);
+        return convertToPageModel(result);
+    }
+
+    // 내용으로 검색
+    public PageModelDto<NewsFeedResponseDto> searchByContent(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<NewsFeed> result = newsFeedRepository.findByContentsContaining(keyword, pageable);
+        return convertToPageModel(result);
+    }
+
+    // 제목 + 내용 검색
+    public PageModelDto<NewsFeedResponseDto> searchByTitleOrContent(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<NewsFeed> result = newsFeedRepository.findByTitleContainingOrContentsContaining(keyword, keyword, pageable);
+        return convertToPageModel(result);
+    }
+
+    // 공통 변환 메서드 (중복 제거)
+    private PageModelDto<NewsFeedResponseDto> convertToPageModel(Page<NewsFeed> result) {
+        if (result.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "검색된 피드가 없습니다.");
+        }
+        List<NewsFeedResponseDto> searchedDtos = result.getContent().stream()
+                .map(NewsFeedResponseDto::fromEntity)
+                .collect(Collectors.toList());
+        return new PageModelDto<>(searchedDtos, result.getNumber() + 1, result.getSize(), result.getTotalElements());
+    }
 }

--- a/src/main/java/com/tbgram/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/tbgram/domain/profile/controller/ProfileController.java
@@ -1,7 +1,0 @@
-package com.tbgram.domain.profile.controller;
-
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class ProfileController {
-}


### PR DESCRIPTION
- newsfeed/service, repository, controller 하단에 작성
- 제목검색, 내용검색, 제목+내용 검색
- containing으로 like절 구현 (JpaRepository)

+ 페이징한 Dto로 반환하는 공통 로직을 담은 메소드를 기능별로 묶어 통합해도 좋을 것 같습니당
  -> 일단 검색 기능에서는 검색된 내용이 없었을 때 NOT_FOUND를 반환하기 위해 공통로직을 하나 더 생성했습니다만,
  -> (개인적인 입장으로는) 뉴스피드 부분에 공통적인 부분이 통일화 되지 않은게 조금 있는것 같습니당 🥲🌸😉👊🏻

++ 회원 탈퇴시 세션 제거하는 부분도 추가했습니당 참고 해주세용!😙